### PR TITLE
fix: add in missing env for cloud run container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Local .terraform directories
 **/.terraform/*
+**/.terraform.lock.*
 
 # .tfstate files
 *.tfstate

--- a/infra/apis.tf
+++ b/infra/apis.tf
@@ -49,6 +49,5 @@ resource "time_sleep" "cloud_run_v2_service" {
     google_cloud_run_v2_service.default
   ]
   
-  create_duration = "45s"
+  create_duration = "60s"
 }
-

--- a/infra/apis.tf
+++ b/infra/apis.tf
@@ -44,3 +44,11 @@ resource "time_sleep" "project_services" {
   create_duration = "45s"
 }
 
+resource "time_sleep" "cloud_run_v2_service" {
+  depends_on = [ 
+    google_cloud_run_v2_service.default
+  ]
+  
+  create_duration = "45s"
+}
+

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -15,7 +15,7 @@
  */
 locals {
   nextauth_url      = "http://${google_compute_global_address.default.address}"
-  firestore_enabled = false
+  firestore_enabled = length(data.google_cloud_asset_resources_search_all.firestore_database.results) == 1 ? true : false
 }
 
 ### GCS bucket ###
@@ -273,6 +273,15 @@ resource "google_compute_global_forwarding_rule" "http" {
 }
 
 ### Firestore ###
+
+# The following checks Asset Inventory for an existing Firestore database
+data "google_cloud_asset_resources_search_all" "firestore_database" {
+  provider = google-beta
+  scope    = "projects/${var.project_id}"
+  asset_types = [
+    "firestore.googleapis.com/Database"
+  ]
+}
 
 # If a Firestore database exists on the project, Terraform will skip this resource
 resource "google_firestore_database" "database" {

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -15,7 +15,7 @@
  */
 locals {
   nextauth_url      = "http://${google_compute_global_address.default.address}"
-  firestore_enabled = true
+  firestore_enabled = false
 }
 
 ### GCS bucket ###


### PR DESCRIPTION
**Fixes:**
 - Adds in missing `PROJECT_ID` environment variable necessary for cloud run container (expected by Next.js [ref file](https://github.com/pattishin/developer-journey-app/blob/main/src/lib/database.ts#L32))
 - Adds in timers for resources taking longer to provision (errors out)