### PR TITLE
refactor: remove 'welcome' from link

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Upon successful provisioning, you should see an output similar to:
 
 ```bash
 frontend_url = "http://11.222.333.444/"
-neos_toc_url = "http://console.cloud.google.com/welcome?walkthrough_id=panels--sic--dynamic-javascript-web-app_toc"
+neos_toc_url = "http://console.cloud.google.com?walkthrough_id=panels--sic--dynamic-javascript-web-app_toc"
 run_service_name = "dev-journey"
 ```
 

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -20,7 +20,7 @@ output "frontend_url" {
 
 output "neos_toc_url" {
   description = "Neos Tutorial URL"
-  value       = "http://console.cloud.google.com/welcome?walkthrough_id=panels--sic--dynamic-javascript-web-app_toc"
+  value       = "http://console.cloud.google.com?walkthrough_id=panels--sic--dynamic-javascript-web-app_toc"
 }
 
 output "run_service_name" {


### PR DESCRIPTION
## Description
Fixes b/278043602

Removes "welcome" in tutorial link.

## Checklist
- [ ] Added steps to reproduce the changes in this pull request
- [ ] Added relevant testing in this pull request
- [x] Please **merge** this PR for me once it is approved.
