### PR TITLE
fix: service account account id 

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Upon successful provisioning, you should see an output similar to:
 
 ```bash
 frontend_url = "http://11.222.333.444/"
-neos_toc_url = "http://console.cloud.google.com/welcome?walkthrough_id=panels--sic--dynamic-javascript-web-app_toc"
+neos_toc_url = "http://console.cloud.google.com?walkthrough_id=panels--sic--dynamic-javascript-web-app_toc"
 run_service_name = "dev-journey"
 ```
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -109,7 +109,7 @@ resource "google_secret_manager_secret_iam_binding" "nextauth_secret" {
 
 resource "google_service_account" "cloud_run" {
   project      = var.project_id
-  account_id   = "${var.deployment_name}-run"
+  account_id   = "sa-run"
   display_name = "Service account for ${var.deployment_name} Cloud Run service."
 }
 

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -20,7 +20,7 @@ output "frontend_url" {
 
 output "neos_toc_url" {
   description = "Neos Tutorial URL"
-  value       = "http://console.cloud.google.com/welcome?walkthrough_id=panels--sic--dynamic-javascript-web-app_toc"
+  value       = "http://console.cloud.google.com?walkthrough_id=panels--sic--dynamic-javascript-web-app_toc"
 }
 
 output "run_service_name" {


### PR DESCRIPTION
## Description

Fixes b/277885432

Passing shorter name to service account `account_id` to fit regex `^[a-z](?:[-a-z0-9]{4,28}[a-z0-9])$`

## Checklist
- [ ] Added steps to reproduce the changes in this pull request
- [ ] Added relevant testing in this pull request
- [x] Please **merge** this PR for me once it is approved.
