### PR TITLE
fix: remove optional startup & liveness checks 

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -145,20 +145,6 @@ resource "google_cloud_run_v2_service" "default" {
         name  = "NEXTAUTH_URL"
         value = local.nextauth_url
       }
-      startup_probe {
-        initial_delay_seconds = 45
-        timeout_seconds       = 65
-        period_seconds        = 5
-        failure_threshold     = 5
-        tcp_socket {
-          port = 8080
-        }
-      }
-      liveness_probe {
-        http_get {
-          path = "/"
-        }
-      }
     }
     service_account = google_service_account.cloud_run.email
   }

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -15,7 +15,8 @@
  */
 
 output "frontend_url" {
-  value = "http://${google_compute_global_address.default.address}/"
+  description = "IP address to site. Load balancer expected to take ~5 minutes for it to warm up."
+  value = "http://${google_compute_global_address.default.address}/ (Wait ~5 minutes for it to warm up.)"
 }
 
 output "neos_toc_url" {


### PR DESCRIPTION
## Description
Fixes b/277883939

Removes optional properties `startup_probe` and `liveness_probe`.  To resolve cloud run timeouts during initial `terraform apply`, requires bulking up `initial_delay_seconds` and `timeout` some. Since this is isn't the main focus for the cloud run service at this point, removing till we can revisit adding back (for otel).

To verify:
- Have a GCP project handy
- `terraform init` (initializes), `terraform plan` (shows what you're about to provision), `terraform apply` (start provisioning)
- Ensure that terraform does not timeout on first apply.

## Checklist
- [ ] Added steps to reproduce the changes in this pull request
- [ ] Added relevant testing in this pull request
- [x] Please **merge** this PR for me once it is approved.
