### PR TITLE
fix: Update outputs.tf to stay at solutions deployments page

### DIFF
--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -21,7 +21,7 @@ output "frontend_url" {
 
 output "neos_toc_url" {
   description = "Tutorial URL"
-  value       = "http://console.cloud.google.com?walkthrough_id=solutions-in-console--dynamic-javascript-webapp--dynamic-javascript-webapp_tour"
+  value       = "http://console.cloud.google.com/products/solutions/deployments?walkthrough_id=solutions-in-console--dynamic-javascript-webapp--dynamic-javascript-webapp_tour"
 }
 
 output "run_service_name" {


### PR DESCRIPTION
## Description

neos url must include products/solutions/deployments to avoid navigating back to welcome paage