### PR TITLE
ci: Add major release tagging

### DIFF
--- a/.github/workflows/release-major-tags.yml
+++ b/.github/workflows/release-major-tags.yml
@@ -1,0 +1,57 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: release-major-tags
+
+# Create/update git tags to match the latest major version of any release.
+#
+# These tags are mutable: they are deleted and recreated as needed.
+# Tags are not intended as a way to reference the module by terraform.
+# Assumes we do not backport fixes to previous minor releases.
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-major:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/github-script@v6
+        id: parse-major
+        with:
+          script: |
+            const ref = context.payload.release.tag_name;
+            const versionRegex = new RegExp('v?(\\d+)\\.\\d+\\.\\d+');
+            const match = ref.match(versionRegex);
+            if (match) {
+              return "v" + match[1];
+            }
+            return "";
+          result-encoding: string
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+        if: ${{ steps.parse-major.outputs.result }}
+      - name: delete existing major tag
+        run: |
+          (git tag -d ${{ steps.parse-major.outputs.result }} && git push origin :${{ steps.parse-major.outputs.result }}) || true
+        if: ${{ steps.parse-major.outputs.result }}
+      - name: create major tag
+        run: |
+          git tag ${{ steps.parse-major.outputs.result }} ${{ github.event.GITHUB_REF }}
+          git push origin --tags
+        if: ${{ steps.parse-major.outputs.result }}


### PR DESCRIPTION
## Description

Add major release tagging to match https://github.com/GoogleCloudPlatform/terraform-dynamic-python-webapp/blob/main/.github/workflows/release-major-tags.yml.

This change follow the work of release-please to tag a release to update a major version tag. This allows content to reference this repo based on latest major version, instead of being limited to a specific release or HEAD.

## Checklist
- [ ] Added steps to reproduce the changes in this pull request
- [ ] Added relevant testing in this pull request
- [x] Please **merge** this PR for me once it is approved.
