### PR TITLE
fix: remove db dependency on LB time delay

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -319,7 +319,6 @@ resource "google_firestore_database" "database" {
   concurrency_mode            = "PESSIMISTIC"
   app_engine_integration_mode = "DISABLED"
   depends_on = [
-    time_sleep.project_services,
-    time_sleep.load_balancer_warm_up_time
+    time_sleep.project_services
   ]
 }


### PR DESCRIPTION
## Description

Fixes #62 

This PR removes the dependency on the load balancer warm-up from the Firestore database resource.

**Note:** Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] Added steps to reproduce the changes in this pull request
- [ ] Added relevant testing in this pull request
- [X] Please **merge** this PR for me once it is approved.
