### PR TITLE
fix: added zone to variables

### DIFF
--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -49,6 +49,12 @@ variable "region" {
   description = "Google Cloud region"
 }
 
+variable "zone" {
+  type        = string
+  default     = "us-central1-a"
+  description = "Google Cloud region"
+}
+
 variable "init_firestore" {
   type        = bool
   description = "Whether or not to initialize a Firestore instance."

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -52,7 +52,7 @@ variable "region" {
 variable "zone" {
   type        = string
   default     = "us-central1-a"
-  description = "Google Cloud region"
+  description = "Google Cloud zone"
 }
 
 variable "init_firestore" {


### PR DESCRIPTION
## Description
Adds a new variable to infra/variables.tf for the zone and defaults to the region's `-a` zone

Steps to reproduce: Create a new "Dynamic web application with JavaScript" sample deploy using Terraform CLI

Fixes #80 

**Note:** Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [X] Added steps to reproduce the changes in this pull request
- [ ] Added relevant testing in this pull request
- [ ] Please **merge** this PR for me once it is approved.
