### PR TITLE
chore: update simple_example versions.tf

### DIFF
--- a/infra/examples/simple_example/versions.tf
+++ b/infra/examples/simple_example/versions.tf
@@ -17,8 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source  = "hashicorp/google"
-      version = "~> 4.0"
+      source = "hashicorp/google"
     }
   }
   required_version = ">= 0.13"

--- a/infra/examples/simple_example/versions.tf
+++ b/infra/examples/simple_example/versions.tf
@@ -17,7 +17,8 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source  = "hashicorp/google"
+      version = ">= 4.0"
     }
   }
   required_version = ">= 0.13"


### PR DESCRIPTION
Should fix the `getNewValue`. 

Also it's generally it's best to only set a minimum version in the samples, so the CI will run with the most recent TPG allowed by actual module.

Fixes: https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/issues/2086