### PR TITLE
ci: Add inline guidance on pull_request_target usage

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -14,6 +14,7 @@
 
 name: Auto Label
 on:
+  # Do not use pull_request_target with actions/cache or actions/checkout.
   pull_request_target:
     types: [ opened, reopened, synchronize, edited ]
 


### PR DESCRIPTION
## Description

Add some guidance on safe usage of `pull_request_target`. Initial PR is providing minimal information.

Lines up with GoogleCloudPlatform/avocano.

**Note:** Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] Added steps to reproduce the changes in this pull request
- [ ] Added relevant testing in this pull request
- [ ] Please **merge** this PR for me once it is approved.
