### PR TITLE
fix: set deletion_protection on cloud run

### DIFF
--- a/infra/apis.tf
+++ b/infra/apis.tf
@@ -17,7 +17,7 @@
 # Google Cloud Services to enable
 module "project_services" {
   source                      = "terraform-google-modules/project-factory/google//modules/project_services"
-  version                     = "16.0.1"
+  version                     = "17.0.0"
   disable_services_on_destroy = false
   project_id                  = var.project_id
   enable_apis                 = var.enable_apis

--- a/infra/examples/simple_example/versions.tf
+++ b/infra/examples/simple_example/versions.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.0"
+      version = ">= 6"
     }
   }
 }

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -142,6 +142,8 @@ resource "google_cloud_run_v2_service" "default" {
   location = var.region
   ingress  = "INGRESS_TRAFFIC_ALL"
 
+  deletion_protection = false
+
   template {
     containers {
       image = var.initial_run_image

--- a/infra/test/setup/main.tf
+++ b/infra/test/setup/main.tf
@@ -16,7 +16,7 @@
 
 module "project" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 16.0"
+  version = "~> 17.0"
 
   name              = "ci-javascript-webapp"
   random_project_id = "true"

--- a/infra/test/setup/versions.tf
+++ b/infra/test/setup/versions.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.25.0"
+      version = ">= 6"
     }
   }
 }

--- a/infra/versions.tf
+++ b/infra/versions.tf
@@ -19,12 +19,12 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.83.0, < 7"
+      version = ">= 6, < 7"
     }
 
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.83.0, < 7"
+      version = ">= 6, < 7"
     }
 
     time = {


### PR DESCRIPTION
## Description

Replaces #157 

Adds `deletion_protection` field, ensuring that `terraform destroy` succeeds. 

https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_service#deletion_protection

- [x] Please **merge** this PR for me once it is approved.
